### PR TITLE
Align intervals with Binance API

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -248,13 +248,13 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const intervals = {
-            '1h': '1m',
-            '4h': '5m',
-            '1d': '15m',
-            '1w': '1h'
+            '1h': '1h',
+            '4h': '4h',
+            '1d': '1d',
+            '1w': '1w'
         };
 
-        const limit = 500;
+        const limit = 1000;
         const interval = intervals[selectedInterval];
         
         try {


### PR DESCRIPTION
## Summary
- map chart intervals directly to Binance's 1h, 4h, 1d and 1w periods
- increase klines request limit to 1000 for deeper historical coverage

## Testing
- `curl -s 'https://api3.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1h&limit=10'` *(fails: Service unavailable from a restricted location)*
- `npm test` *(fails: Missing script: "test")*
- `npx eslint public/app.js` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b864192338832c96d32e4dc74d8957