### PR TITLE
fix: use firebase admin for token verification

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,6 +1,6 @@
 const { initializeApp } = require('firebase/app');
-const { getAuth } = require('firebase/auth');
 const { getFirestore } = require('firebase/firestore');
+const admin = require('firebase-admin');
 require('dotenv').config();
 
 const firebaseConfig = {
@@ -13,8 +13,14 @@ const firebaseConfig = {
   measurementId: "G-HFM2LRSKPJ"
 };
 
+// Initialize client SDK for Firestore operations
 const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
 const db = getFirestore(app);
+
+// Initialize Firebase Admin SDK for server-side authentication
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+const auth = admin.auth();
 
 module.exports = { auth, db };


### PR DESCRIPTION
## Summary
- use Firebase Admin SDK on the server so `verifyIdToken` is available

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b86329e9e4832cbc53966e41ed5247