### PR TITLE
Fix TradingView chart display in token detail widget

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -168,12 +168,15 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('detailVolume').textContent = formatNumber(data.volume);
         document.getElementById('detailQuoteVolume').textContent = `$${formatNumber(data.quoteVolume)}`;
         
-        // Initialize or update chart
-        initChart();
-        fetchKlines();
-        
-        // Show modal
+        // Show modal before initializing chart so dimensions are available
         modal.style.display = 'block';
+
+        // Initialize or update chart after modal is visible
+        requestAnimationFrame(() => {
+            initChart();
+            fetchKlines();
+        });
+
         stopAutoRefresh();
     };
 


### PR DESCRIPTION
## Summary
- Ensure modal is visible before creating chart to allow proper sizing
- Initialize chart on the next frame after modal visibility

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8631ac3bc832cacd0cb33eb06473f