### PR TITLE
fix chart modal initialization issue

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -169,14 +169,18 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('detailVolume').textContent = formatNumber(data.volume);
         document.getElementById('detailQuoteVolume').textContent = `$${formatNumber(data.quoteVolume)}`;
         
+        // Show modal first so chart container has dimensions
+        modal.style.display = 'block';
+
         // Initialize or update chart
+        const chartContainer = document.getElementById('priceChart');
         if (!chart || !candlestickSeries) {
             initChart();
+        } else if (chartContainer) {
+            chart.resize(chartContainer.clientWidth, 400);
         }
+
         fetchKlines();
-        
-        // Show modal
-        modal.style.display = 'block';
         stopAutoRefresh();
     };
 


### PR DESCRIPTION
## Summary
- ensure detail modal is shown before initializing price chart
- resize existing charts when reopening the modal

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint .` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68b95f4c449c832cb7fa02c14bed1979