### PR TITLE
fix chart not shown in token detail modal

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -168,20 +168,21 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('detailLow').textContent = `$${formatPrice(data.lowPrice)}`;
         document.getElementById('detailVolume').textContent = formatNumber(data.volume);
         document.getElementById('detailQuoteVolume').textContent = `$${formatNumber(data.quoteVolume)}`;
-        
+
         // Show modal first so chart container has dimensions
         modal.style.display = 'block';
-
-        // Initialize or update chart
-        const chartContainer = document.getElementById('priceChart');
-        if (!chart || !candlestickSeries) {
-            initChart();
-        } else if (chartContainer) {
-            chart.resize(chartContainer.clientWidth, 400);
-        }
-
-        fetchKlines();
         stopAutoRefresh();
+
+        // Initialize chart after modal is rendered to ensure proper dimensions
+        requestAnimationFrame(() => {
+            const chartContainer = document.getElementById('priceChart');
+            if (!chart || !candlestickSeries) {
+                initChart();
+            } else if (chartContainer) {
+                chart.resize(chartContainer.clientWidth, 400);
+            }
+            fetchKlines();
+        });
     };
 
     // Initialize chart


### PR DESCRIPTION
## Summary
- ensure candlestick chart initializes after modal becomes visible
- stop auto refresh before rendering chart

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint public/app.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b73397a0832ca55f20acf5b2772d